### PR TITLE
Implement tour service breakdown and pax config

### DIFF
--- a/src/main/java/com/fpt/capstone/tourism/controller/business/TourManagementController.java
+++ b/src/main/java/com/fpt/capstone/tourism/controller/business/TourManagementController.java
@@ -4,9 +4,12 @@ import com.fpt.capstone.tourism.dto.general.GeneralResponse;
 
 import com.fpt.capstone.tourism.dto.request.ChangeStatusDTO;
 import com.fpt.capstone.tourism.dto.request.tourManager.TourDayCreateRequestDTO;
+import com.fpt.capstone.tourism.dto.request.tourManager.TourPaxCreateRequestDTO;
 import com.fpt.capstone.tourism.dto.request.tourManager.TourUpdateRequestDTO;
+import com.fpt.capstone.tourism.dto.response.tourManager.ServiceBreakdownDTO;
 import com.fpt.capstone.tourism.dto.response.tourManager.TourDayDTO;
 import com.fpt.capstone.tourism.dto.response.tourManager.TourDetailDTO;
+import com.fpt.capstone.tourism.dto.response.tourManager.TourPaxDTO;
 import com.fpt.capstone.tourism.dto.response.tourManager.TourResponseDTO;
 import com.fpt.capstone.tourism.service.TourManagementService;
 import lombok.RequiredArgsConstructor;
@@ -84,6 +87,19 @@ public class TourManagementController {
     public ResponseEntity<GeneralResponse<String>> deleteTourDay(@PathVariable Long tourId,
                                                                  @PathVariable Long dayId) {
         return ResponseEntity.ok(tourManagementService.deleteTourDay(tourId, dayId));
+    }
+
+    // Chiết tính dịch vụ của tour
+    @GetMapping("/tours/{id}/services")
+    public ResponseEntity<GeneralResponse<List<ServiceBreakdownDTO>>> getTourServices(@PathVariable Long id) {
+        return ResponseEntity.ok(tourManagementService.getServiceBreakdown(id));
+    }
+
+    // Tạo cấu hình số lượng khách cho tour
+    @PostMapping("/tours/{id}/pax")
+    public ResponseEntity<GeneralResponse<TourPaxDTO>> createTourPax(@PathVariable Long id,
+                                                                     @RequestBody TourPaxCreateRequestDTO requestDTO) {
+        return ResponseEntity.ok(tourManagementService.createTourPax(id, requestDTO));
     }
 
 }

--- a/src/main/java/com/fpt/capstone/tourism/dto/request/tourManager/TourPaxCreateRequestDTO.java
+++ b/src/main/java/com/fpt/capstone/tourism/dto/request/tourManager/TourPaxCreateRequestDTO.java
@@ -1,0 +1,13 @@
+package com.fpt.capstone.tourism.dto.request.tourManager;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class TourPaxCreateRequestDTO {
+    private int minQuantity;
+    private int maxQuantity;
+}

--- a/src/main/java/com/fpt/capstone/tourism/dto/response/tourManager/ServiceBreakdownDTO.java
+++ b/src/main/java/com/fpt/capstone/tourism/dto/response/tourManager/ServiceBreakdownDTO.java
@@ -1,0 +1,19 @@
+package com.fpt.capstone.tourism.dto.response.tourManager;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ServiceBreakdownDTO {
+    private int dayNumber;
+    private String serviceTypeName;
+    private String partnerName;
+    private String partnerAddress;
+    private double nettPrice;
+    private double sellingPrice;
+}

--- a/src/main/java/com/fpt/capstone/tourism/dto/response/tourManager/TourPaxDTO.java
+++ b/src/main/java/com/fpt/capstone/tourism/dto/response/tourManager/TourPaxDTO.java
@@ -1,0 +1,16 @@
+package com.fpt.capstone.tourism.dto.response.tourManager;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class TourPaxDTO {
+    private Long id;
+    private int minQuantity;
+    private int maxQuantity;
+}

--- a/src/main/java/com/fpt/capstone/tourism/repository/tour/TourPaxRepository.java
+++ b/src/main/java/com/fpt/capstone/tourism/repository/tour/TourPaxRepository.java
@@ -1,0 +1,12 @@
+package com.fpt.capstone.tourism.repository.tour;
+
+import com.fpt.capstone.tourism.model.tour.TourPax;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface TourPaxRepository extends JpaRepository<TourPax, Long> {
+    List<TourPax> findByTourId(Long tourId);
+}

--- a/src/main/java/com/fpt/capstone/tourism/service/TourManagementService.java
+++ b/src/main/java/com/fpt/capstone/tourism/service/TourManagementService.java
@@ -3,9 +3,12 @@ package com.fpt.capstone.tourism.service;
 import com.fpt.capstone.tourism.dto.general.GeneralResponse;
 import com.fpt.capstone.tourism.dto.request.ChangeStatusDTO;
 import com.fpt.capstone.tourism.dto.request.tourManager.TourDayCreateRequestDTO;
+import com.fpt.capstone.tourism.dto.request.tourManager.TourPaxCreateRequestDTO;
 import com.fpt.capstone.tourism.dto.request.tourManager.TourUpdateRequestDTO;
+import com.fpt.capstone.tourism.dto.response.tourManager.ServiceBreakdownDTO;
 import com.fpt.capstone.tourism.dto.response.tourManager.TourDayDTO;
 import com.fpt.capstone.tourism.dto.response.tourManager.TourDetailDTO;
+import com.fpt.capstone.tourism.dto.response.tourManager.TourPaxDTO;
 import com.fpt.capstone.tourism.dto.response.tourManager.TourResponseDTO;
 import org.springframework.stereotype.Service;
 
@@ -29,4 +32,14 @@ public interface TourManagementService {
     GeneralResponse<TourDayDTO> updateTourDay(Long tourId, Long dayId, TourDayCreateRequestDTO requestDTO);
 
     GeneralResponse<String> deleteTourDay(Long tourId, Long dayId);
+
+    /**
+     * Retrieve a breakdown of all services belonging to the tour.
+     */
+    GeneralResponse<List<ServiceBreakdownDTO>> getServiceBreakdown(Long tourId);
+
+    /**
+     * Create a pax configuration for the specified tour.
+     */
+    GeneralResponse<TourPaxDTO> createTourPax(Long tourId, TourPaxCreateRequestDTO requestDTO);
 }


### PR DESCRIPTION
## Summary
- add API models for service breakdown and pax config
- allow listing services in a tour with prices
- support creating tour pax configuration

## Testing
- `./mvnw -q test` *(fails: Failed to fetch dependencies)*

------
https://chatgpt.com/codex/tasks/task_b_685835bda3cc8322842b6bf896576fc1